### PR TITLE
OOM handling for local_strdup.c

### DIFF
--- a/local_strdup.c
+++ b/local_strdup.c
@@ -23,6 +23,10 @@ char *local_strdup_safe(const char *s) {
 			n = MAX_STRDUP;
 		}
 		ret = (char *) malloc(n + 1);
+		if (ret == NULLPTR) {
+			printf("ERROR - Out of memory!");
+			return NULLPTR;
+		}
 		memcpy(ret,s,n);
 		*(ret+n) = '\0';
 	}


### PR DESCRIPTION
It is possible for the malloc to fail. We should not do memcpy, unless we know ret is not a NULLPTR.